### PR TITLE
Fixing lisp_fn macro functionality to work with new pdumper logic.

### DIFF
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -27,6 +27,7 @@ extern crate core;
 extern crate remacs_lib;
 extern crate remacs_macros;
 
+#[macro_use]
 mod remacs_sys;
 #[macro_use]
 mod lisp;

--- a/rust_src/src/lisp.rs
+++ b/rust_src/src/lisp.rs
@@ -6,6 +6,7 @@ use libc::{c_void, intptr_t};
 use crate::{
     remacs_sys::EmacsInt,
     remacs_sys::{Qnil, Qt, VALMASK},
+    remacs_sys::Aligned_Lisp_Subr,
 };
 
 // TODO: tweak Makefile to rebuild C files if this changes.
@@ -104,5 +105,12 @@ impl<T> Clone for ExternalPtr<T> {
 impl<T> ExternalPtr<T> {
     pub const fn new(p: *mut T) -> Self {
         Self(p)
+    }
+}
+
+pub type LispSubrRef = ExternalPtr<Aligned_Lisp_Subr>;
+impl LispSubrRef {
+    pub fn as_mut(self) -> *mut Aligned_Lisp_Subr {
+	self.0
     }
 }

--- a/rust_src/src/remacs_sys.rs
+++ b/rust_src/src/remacs_sys.rs
@@ -131,6 +131,21 @@ pub const WAIT_READING_MAX: i64 = i64::max_value();
 //
 // Based on http://stackoverflow.com/a/28116557/509706
 unsafe impl Sync for Lisp_Subr {}
+unsafe impl Sync for Aligned_Lisp_Subr {}
+unsafe impl Sync for crate::lisp::LispSubrRef {}
+
+macro_rules! export_lisp_fns {
+    ($($(#[$($meta:meta),*])* $f:ident),+) => {
+	pub fn rust_init_syms() {
+	    #[allow(unused_unsafe)] // just in case the block is empty
+	    unsafe {
+		$(
+		    $(#[$($meta),*])* crate::remacs_sys::defsubr(concat_idents!(S, $f).as_mut());
+		)+
+	    }
+	}
+    }
+}
 
 pub type Lisp_Buffer = buffer;
 pub type Lisp_Font_Object = font;


### PR DESCRIPTION
This PR repairs the ability to use the #[lisp_fn] macro to define Rust functions callable from emacs. Previously in remacs, we called "xmalloc", and left the pointer linger on the heap for the duration of the program. Changes to the emacs build process (including pdump and unexec) have made this no longer viable. Instead I have opt'd to use the MaybeUninit construct to make an actual aligned and uninitialized struct that we can fill with data and hand off to the C layer.  

Basic functionality test can be performed via the following patch applied to this branch:

```
diff --git a/rust_src/src/example.rs b/rust_src/src/example.rs
new file mode 100644
index 0000000000..d91ad58bf2
--- /dev/null
+++ b/rust_src/src/example.rs
@@ -0,0 +1,9 @@
+use lazy_static::lazy_static;
+use remacs_macros::lisp_fn;
+
+#[lisp_fn]
+pub fn eptn(t: crate::lisp::LispObject) -> crate::lisp::LispObject {
+    crate::lisp::LispObject::from(true)
+}
+
+include!(concat!(env!("OUT_DIR"), "/example_exports.rs"));
diff --git a/rust_src/src/lib.rs b/rust_src/src/lib.rs
index bd9efb24b5..3016f87696 100755
--- a/rust_src/src/lib.rs
+++ b/rust_src/src/lib.rs
@@ -31,6 +31,7 @@ extern crate remacs_macros;
 mod remacs_sys;
 #[macro_use]
 mod lisp;
+mod example;

 #[cfg(not(test))]
 include!(concat!(env!("OUT_DIR"), "/c_exports.rs"));
```