### PR TITLE
Fixing ability to use inline functions in rust layer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5617,10 +5617,10 @@ AC_SUBST(CARGO_FLAGS)
 case "${opsys}" in
   darwin) RUST_DEPS="-ldl -lm -lresolv"
         REMACSLIB_NAME="libremacs_lib.a"
-        REMACSLIB_CFLAGS="-pthread" ;;
+        REMACSLIB_CFLAGS="-pthread -DEMACS_EXTERN_INLINE" ;;
   gnu*) RUST_DEPS="-ldl -lm -lrt"
         REMACSLIB_NAME="libremacs_lib.a"
-        REMACSLIB_CFLAGS="-pthread" ;;
+        REMACSLIB_CFLAGS="-pthread -DEMACS_EXTERN_INLINE" ;;
 esac
 
 if test "${HAVE_W32}" = "yes"; then

--- a/rust_src/remacs-bindings/src/main.rs
+++ b/rust_src/remacs-bindings/src/main.rs
@@ -236,6 +236,7 @@ fn run_bindgen(path: &str) {
 
             builder = builder
                 .clang_arg("-Demacs")
+                .clang_arg("-DEMACS_EXTERN_INLINE")
                 .header("../rust_src/wrapper.h")
                 .generate_inline_functions(true)
                 .derive_default(true)


### PR DESCRIPTION
Addresses https://github.com/remacs/emacs-webrender/issues/14

Emacs commit https://github.com/remacs/emacs-webrender/commit/365dad197bac5deec9244fd9c189d23c46c99b31 introduced an optimization where the inline functionality is implemented via the keyword "static" instead of "inline". This causes problems for bindgen, resulting in bindgen not generating appropriate rust bindings. In addition, using "static" will not enable us to link against those functions and call them from Rust. 

By defining EMACS_EXTERN_INLINE in the C pre-processor, we can get the behavior we had in remacs in terms of inline functions. 

Its unfortunate that this will likely cause a performance regression, however I can't think of a better solution without reimplementing these inline functions in Rust. 

Comment from conf_post.h with some amplifying information: 
```
INLINE is implemented via C99-style 'extern inline' if Emacs is built
   with -DEMACS_EXTERN_INLINE; otherwise it is implemented via 'static'.
   EMACS_EXTERN_INLINE is no longer the default, as 'static' seems to
   have better performance with GCC.
```